### PR TITLE
update bundle install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache --update ruby-nokogiri \
 WORKDIR /tmp
 ADD Gemfile /tmp/
 ADD Gemfile.lock /tmp/
-RUN bundle install --jobs 4 --retry 3
+RUN bundle install --jobs `expr $(cat /proc/cpuinfo | grep -c "cpu cores") - 1` --retry 3
 
 # Copy the application into the container
 COPY . /usr/src/app


### PR DESCRIPTION
make the number of jobs equal to the current system's number of cores, minus 1

Why:

* statically setting the number of cores doesn't work well for systems with more/less cores
* some benchmarks have found that setting the number of jobs to one fewer than the total number of available cores produces the best results

How:

* replace the static jobs value with the result of a core-counting query
* subtracting 1 from the total core count, for performance
* not using the `sysctl -n hw.ncpu` query from the Thoughtbot post linked below, because that is not available in alpine linux

Relevant Links:

* https://robots.thoughtbot.com/parallel-gem-installing-using-bundler
* http://archlever.blogspot.com/2013/09/lies-damned-lies-and-truths-backed-by.html